### PR TITLE
Use safe filenames for GTDB-Tk input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # kb_gtdbtk release notes
 =========================================
 
+0.1.0
+_____
+* Fixed a bug where workspace objects with pipe in the name would cause GTDB-Tk to fail.
+
 0.0.5
 _____
 * Updated to GTDB-Tk v0.3.3

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,10 +8,10 @@ service-language:
     python
 
 module-version:
-    0.0.5
+    0.1.0
 
 owners:
-    [psdehal, donovan_parks, Aaron, pchaumeil]
+    [psdehal, donovan_parks, Aaron, pchaumeil, gaprice]
 
 data-version:
     0.0.3

--- a/lib/kb_gtdbtk/utils/gtdbtk_utils.py
+++ b/lib/kb_gtdbtk/utils/gtdbtk_utils.py
@@ -38,7 +38,6 @@ class GTDBTkUtils():
              "classify_wf",
              "--out_dir", output_path,
              "--batchfile", tf.name,
-             "-x", "fa",
              "--cpus", str(self.cpus), 
              "--min_perc_aa", str(min_perc_aa), '"'])
         logging.info("Starting Command:\n" + gtdbtk_cmd)


### PR DESCRIPTION
Seems to choke on filenames with '|' in them.

Also don't use /tmp to store temp files, use the scratch space. There have been issues
with storing files in /tmp in other modules.