### PR TITLE
Fix build attempt 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ MAINTAINER KBase Developer
 # installation scripts.
 
 RUN apt-get update
+
 RUN conda create --name py2 python=2.7 --yes
 RUN echo "source activate py2" > ~/.bashrc
-ENV PATH /miniconda/envs/py2/bin:$PATH
 RUN /bin/bash -c 'echo "installing gtdbtk v0.3.3"'
 RUN conda install -c bioconda gtdbtk -n py2 --yes
 ENV GTDBTK_DATA_PATH=/data
-RUN conda install pandas
+# conda updates to py 3.8 and everything breaks
+RUN pip install pandas
 
 
 # -----------------------------------------


### PR DESCRIPTION
conda was updating python to 3.8 on the pandas install. That shouldn't
cause problems but here we are. In kb-sdk test nose and jinja2 couldn't be found
after the conda install. pip seems to work.

Removed a path statement that doesn't appear to be necessary and was
making pip install pandas in the wrong place.