### PR TITLE
whoops

### DIFF
--- a/lib/kb_gtdbtk/utils/gtdbtk_utils.py
+++ b/lib/kb_gtdbtk/utils/gtdbtk_utils.py
@@ -49,7 +49,9 @@ class GTDBTkUtils():
         mkdir_p(env['TMPDIR'])
         # should figure a way of getting this to run without shell=True, security risk
         # https://docs.python.org/3.7/library/subprocess.html#security-considerations
-        subprocess.check_output(gtdbtk_cmd, shell=True, env=env).decode('utf-8')
+        # probably some way of getting the output to print in real time rather than
+        # all at once at the end
+        output = subprocess.check_output(gtdbtk_cmd, shell=True, env=env).decode('utf-8')
 
         self._process_output_files(output_path, id_to_obj_info)
         return output


### PR DESCRIPTION
that explains the weird ordering of the logs - the output from the program
was printed twice, once right after the program finished and once after the
output files were processed