### PR TITLE
Reduce report size drastically

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ _____
 * Fixed a bug where binned contigs with arbitrary characters in the name could cause GTDB-Tk to
   fail.
 * Fixed copy of a copy / lost permissions issues.
+* Drastically reduced the size of the report zip file, which should speed up load time for
+  the HTML report's first load.
 
 0.0.6
 _____

--- a/lib/kb_gtdbtk/kb_gtdbtkImpl.py
+++ b/lib/kb_gtdbtk/kb_gtdbtkImpl.py
@@ -84,9 +84,11 @@ class kb_gtdbtk:
 
         logging.info("Run gtdbtk classifywf\n")
         output_path = os.path.join(self.shared_folder, 'output')
+        temp_output = os.path.join(self.shared_folder, 'temp_output')
         mkdir_p(output_path)
+        mkdir_p(temp_output)
         gtdbtku = GTDBTkUtils(self.config, self.callback_url, workspace_id, self.cpus)
-        results = gtdbtku.gtdbtk_classifywf(output_path, min_perc_aa, id_to_assy_info)
+        results = gtdbtku.gtdbtk_classifywf(temp_output, output_path, min_perc_aa, id_to_assy_info)
         logging.info(results)
        
         output = create_html_report(

--- a/lib/kb_gtdbtk/utils/gtdbtk_utils.py
+++ b/lib/kb_gtdbtk/utils/gtdbtk_utils.py
@@ -5,6 +5,7 @@ import logging
 import pandas as pd
 import json
 import tempfile
+from shutil import copyfile
 
 from .misc_utils import mkdir_p
 
@@ -22,7 +23,7 @@ class GTDBTkUtils():
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
                             level=logging.INFO)
 
-    def gtdbtk_classifywf(self, output_path, min_perc_aa, id_to_assy_info):
+    def gtdbtk_classifywf(self, temp_output, output_path, min_perc_aa, id_to_assy_info):
         '''
         Run the classify workflow on the fasta files
         '''
@@ -38,7 +39,7 @@ class GTDBTkUtils():
         gtdbtk_cmd = " ".join(
             [self.gtdbtk,
              "classify_wf",
-             "--out_dir", output_path,
+             "--out_dir", temp_output,
              "--batchfile", tf.name,
              "--cpus", str(self.cpus), 
              "--min_perc_aa", str(min_perc_aa), '"'])
@@ -53,20 +54,23 @@ class GTDBTkUtils():
         # all at once at the end
         output = subprocess.check_output(gtdbtk_cmd, shell=True, env=env).decode('utf-8')
 
-        self._process_output_files(output_path, id_to_assy_info)
+        self._process_output_files(temp_output, output_path, id_to_assy_info)
         return output
     
-    def _process_output_files(self, out_dir, id_to_assy_info):
+    def _process_output_files(self, temp_output, out_dir, id_to_assy_info):
 
-        for path in (os.path.join(out_dir, 'gtdbtk.ar122.summary.tsv'),
-                     os.path.join(out_dir, 'gtdbtk.bac120.summary.tsv'),
-                     os.path.join(out_dir, 'gtdbtk.bac120.markers_summary.tsv'),
-                     os.path.join(out_dir, 'gtdbtk.ar122.markers_summary.tsv')): #),
-                     # skip filtered for now, unused, not clear how to test
-                     #os.path.join(out_dir, 'gtdbtk.filtered.tsv')):
-            if not os.path.isfile(path):
-                logging.info('No such file, skipping: ' + path)
+        for file_ in ('gtdbtk.ar122.summary.tsv',
+                      'gtdbtk.bac120.summary.tsv',
+                      'gtdbtk.bac120.markers_summary.tsv',
+                      'gtdbtk.ar122.markers_summary.tsv'):
+                      # skip filtered for now, unused
+                      #'gtdbtk.filtered.tsv'):
+            tmppath = os.path.join(temp_output, file_)
+            if not os.path.isfile(tmppath):
+                logging.info('No such file, skipping: ' + tmppath)
             else:
+                path = os.path.join(out_dir, file_)
+                copyfile(tmppath, path)
                 summary_df = pd.read_csv(path, sep='\t', encoding='utf-8')
                 outfile = path + '.json'
                 summary_json = '{"data": ' + summary_df.to_json(orient='records') + '}'


### PR DESCRIPTION
The report zip currently includes massive amounts of intermediate data (500MB
in one case) that slows down loading of the UI in the narrative when the html
is opened for the first time and the zip
file is fetched from Shock and cached by the HTMLFileService.