### PR TITLE
Remove VScode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/local/bin/python3"
-}


### PR DESCRIPTION
Otherwise developers using VScode clobber each other's configs

NOTE:
* This will delete developers' current VScode configurations on pull.
* After pulling and recreating the config, to avoid re-adding run:

```
git update-index --skip-worktree .vscode/settings.json
```

See https://stackoverflow.com/questions/1274057/how-to-make-git-forget-about-a-file-that-was-tracked-but-is-now-in-gitignore