### PR TITLE
Generate safe IDs in runner, not downloader

### DIFF
--- a/lib/kb_gtdbtk/core/gtdbtk_runner.py
+++ b/lib/kb_gtdbtk/core/gtdbtk_runner.py
@@ -40,7 +40,6 @@ def run_gtdbtk(
     '''
     # TODO input checking
     # TODO test logging, need to install an interceptor. Tested manually for now
-    # TODO FOR REAL abstract the unique ID part here rather than in the downloader
 
     # all this complication is due to GTDB-tk choking on many legal, but uncommon, file name
     # characters such as |. Essentially here we provide safe file names and identitifers

--- a/lib/kb_gtdbtk/core/gtdbtk_runner.py
+++ b/lib/kb_gtdbtk/core/gtdbtk_runner.py
@@ -4,6 +4,7 @@ Run GTDB-tk against a set of sequence files.
 
 import logging
 import json
+import os
 import pandas as pd
 import tempfile
 
@@ -14,7 +15,7 @@ from typing import Dict, List, Callable
 
 def run_gtdbtk(
         gtdbtk_runner: Callable[[List[str]], None],
-        sequences: Dict[str, Dict[str, str]],
+        sequences: Dict[Path, str],
         output_dir: Path,
         temp_dir: Path,
         min_perc_aa: float,
@@ -27,10 +28,8 @@ def run_gtdbtk(
 
     :param gtdbtk_runner: a callable that takes a list of arguments for GTDB-tk and
         excutes the program with those arguments.
-    :param sequences: Information about the fasta files. A mapping from a unique, filename safe
-        ID for each file to another mapping containing the keys 'path', which maps to the path
-        to the FASTA file, and 'assembly_name', which is the name of the assembly to use in
-        the ouput.
+    :param sequences: Information about the fasta files. A mapping from a file path to a display
+        name for the file, often simply the file name.
     :param output_dir: an extant directory in which to place the output. The output is JSON
         versions of GTDB-tk's TSV output using the 'assembly_name' from the sequences map
         as the sequence name.
@@ -41,21 +40,26 @@ def run_gtdbtk(
     '''
     # TODO input checking
     # TODO test logging, need to install an interceptor. Tested manually for now
-    # TODO disallow numbers in string form as IDs - pandas will load it as a number -> KeyError
     # TODO FOR REAL abstract the unique ID part here rather than in the downloader
 
     # all this complication is due to GTDB-tk choking on many legal, but uncommon, file name
     # characters such as |. Essentially here we provide safe file names and identitifers
     # (which GTDB-tk will use to create temporary files) and then remap to the original,
     # potentially unsafe names.
+    temp_links = temp_dir / 'links'
+    temp_links.mkdir(parents=True, exist_ok=True)
+    id_to_name = {}
     with tempfile.NamedTemporaryFile(
             mode='w',
             prefix='gtdb_tk_file_input_',
             suffix='.tmp',
             delete=False,
             dir=temp_dir) as tf:
-        for id_ in sorted(sequences):
-            tf.write(sequences[id_]['path'] + '\t' + id_ + '\n')
+        for i, path in enumerate(sorted(sequences)):
+            id_ = f'id{i}'
+            id_to_name[id_] = sequences[path]
+            os.symlink(path, temp_links / id_)
+            tf.write(str(temp_links / id_) + '\t' + id_ + '\n')
 
     temp_output = temp_dir / 'output'
     temp_output.mkdir(parents=True, exist_ok=True)
@@ -70,10 +74,10 @@ def run_gtdbtk(
 
     logging.info('Starting Command:\n' + ' '.join(gtdbtk_cmd))
     gtdbtk_runner(gtdbtk_cmd)
-    _process_output_files(temp_output, output_dir, sequences)
+    _process_output_files(temp_output, output_dir, id_to_name)
 
 
-def _process_output_files(temp_output, out_dir, sequences):
+def _process_output_files(temp_output, out_dir, id_to_name):
 
     for file_ in ('gtdbtk.ar122.summary.tsv',
                   'gtdbtk.bac120.summary.tsv',
@@ -94,7 +98,7 @@ def _process_output_files(temp_output, out_dir, sequences):
             sj = json.loads(summary_json)
             for item in sj['data']:
                 key = 'Name' if 'Name' in item else 'user_genome'
-                item[key] = sequences[item[key]]['assembly_name']
+                item[key] = id_to_name[item[key]]
 
             with open(outfile, 'w') as out:
                 out.write(json.dumps(sj))

--- a/test/core/gtdbtk_runner_test.py
+++ b/test/core/gtdbtk_runner_test.py
@@ -42,20 +42,20 @@ def test_gtdbtk_run():
 
             with open(temp_out / 'gtdbtk.ar122.summary.tsv', 'w') as t:
                 t.writelines(['\t'.join(['Name', 'field1', 'field2']) + '\n',
-                              '\t'.join(['a1', 'foo', 'bar']) + '\n',
-                              '\t'.join(['a2', 'baz', 'bat']) + '\n',
+                              '\t'.join(['id0', 'foo', 'bar']) + '\n',
+                              '\t'.join(['id1', 'baz', 'bat']) + '\n',
                               ])
 
             with open(temp_out / 'gtdbtk.bac120.summary.tsv', 'w') as t:
                 t.writelines(['\t'.join(['Name', 'field1', 'field2']) + '\n',
-                              '\t'.join(['a1', 'whoo', 'whee']) + '\n',
-                              '\t'.join(['a2', 'whoa', 'whump']) + '\n',
+                              '\t'.join(['id0', 'whoo', 'whee']) + '\n',
+                              '\t'.join(['id1', 'whoa', 'whump']) + '\n',
                               ])
 
             with open(temp_out / 'gtdbtk.bac120.markers_summary.tsv', 'w') as t:
                 t.writelines(['\t'.join(['user_genome', 'field1', 'field2']) + '\n',
-                              '\t'.join(['a1', 'fee', 'fie']) + '\n',
-                              '\t'.join(['a2', 'fo', 'fum']) + '\n',
+                              '\t'.join(['id0', 'fee', 'fie']) + '\n',
+                              '\t'.join(['id1', 'fo', 'fum']) + '\n',
                               ])
 
             # skip 'gtdbtk.ar122.markers_summary.tsv'
@@ -64,8 +64,8 @@ def test_gtdbtk_run():
 
         run_gtdbtk(
             runner,
-            {'a1': {'path': '/somepath1', 'assembly_name': 'somefile1.fasta'},
-             'a2': {'path': '/somepath2', 'assembly_name': 'somefile2.fasta'},
+            {Path('/somepath1'): 'somefile1.fasta',
+             Path('/somepath2'): 'somefile2.fasta',
              },
             out_dir,
             temp_dir,
@@ -76,8 +76,11 @@ def test_gtdbtk_run():
         with open(tf[0]) as bf:
             lines = bf.readlines()
             assert len(lines) == 2
-            assert lines[0] == '/somepath1\ta1\n'
-            assert lines[1] == '/somepath2\ta2\n'
+            assert lines[0] == f'{temp_dir}/links/id0\tid0\n'
+            assert lines[1] == f'{temp_dir}/links/id1\tid1\n'
+
+        assert os.readlink(temp_dir / 'links' / 'id0') == '/somepath1'
+        assert os.readlink(temp_dir / 'links' / 'id1') == '/somepath2'
 
         assert sorted(os.listdir(out_dir)) == [
             'gtdbtk.ar122.summary.tsv',

--- a/test/core/sequence_downloader_test.py
+++ b/test/core/sequence_downloader_test.py
@@ -109,9 +109,7 @@ def _check_genomeset(type_, data):
 
     ret = download_sequence('34567/3/7', Path('somepath/or/other'), clis)
 
-    assert ret == {'45_21_89': {'path': '/path/to/file1', 'assembly_name': 'assyname1'},
-                   '7_8_9': {'path': '/path/to/file2', 'assembly_name': 'assyname2'}
-                   }
+    assert ret == {Path('/path/to/file1'): 'assyname1', Path('/path/to/file2'): 'assyname2'}
 
     assert clis.dfu().get_objects.call_args_list == [(({'object_refs': ['34567/3/7']},), {})]
 
@@ -162,8 +160,7 @@ def _check_genome(ref_key):
 
     ret = download_sequence('34567/3/7', Path('somepath/or/other'), clis)
 
-    assert ret == {'1_2_3': {'path': '/path/to/file3', 'assembly_name': 'assyname3'}
-                   }
+    assert ret == {Path('/path/to/file3'): 'assyname3'}
 
     assert clis.dfu().get_objects.call_args_list == [(({'object_refs': ['34567/3/7']},), {})]
 
@@ -208,8 +205,7 @@ def _check_assembly(type_):
 
     ret = download_sequence('34567/3/7', Path('somepath/or/other'), clis)
 
-    assert ret == {'34567_3_7': {'path': '/path/to/file4', 'assembly_name': 'assyname4'}
-                   }
+    assert ret == {Path('/path/to/file4'): 'assyname4'}
 
     assert clis.dfu().get_objects.call_args_list == [(({'object_refs': ['34567/3/7']},), {})]
 
@@ -288,9 +284,7 @@ def test_with_assemblyset():
 
     ret = download_sequence('34567/3/7', Path('somepath/or/other'), clis)
 
-    assert ret == {'1_2_3': {'path': '/path/to/file1', 'assembly_name': 'assyname1'},
-                   '4_5_6': {'path': '/path/to/file2', 'assembly_name': 'assyname2'}
-                   }
+    assert ret == {Path('/path/to/file1'): 'assyname1', Path('/path/to/file2'): 'assyname2'}
 
     assert clis.dfu().get_objects.call_args_list == [(({'object_refs': ['34567/3/7']},), {})]
 
@@ -322,13 +316,6 @@ def test_with_binnedcontigs():
         ]
     }
 
-    uuid1 = 'f2f17834-d2ed-4ec3-aedd-5f981ad3444f'
-    uuid2 = 'd0a5665e-bd74-4f53-aedf-fc1f29d3f369'
-    uuids = [uuid1, uuid2]
-
-    def ugen():
-        return uuids.pop(0)
-
     with tempfile.TemporaryDirectory(prefix='test_with_binned_contigs_') as td:
         tempdir = Path(td) / 'temp'
         tempdir.mkdir(parents=True, exist_ok=True)
@@ -341,24 +328,13 @@ def test_with_binnedcontigs():
 
         clis.mgu().binned_contigs_to_file.return_value = {'bin_file_directory': tempdir}
 
-        ret = download_sequence('34567/3/7', outdir, clis, ugen)
+        ret = download_sequence('34567/3/7', outdir, clis)
 
         # could put contents in file and check, but YAGNI. If things get more complicated do it
-        assert (outdir / uuid1).exists()
-        assert (outdir / uuid2).exists()
+        assert (outdir / 'file1.fa').exists()
+        assert (outdir / 'file2.fa').exists()
 
-    ret1 = {
-        uuid1: {'path': outdir / uuid1, 'assembly_name': 'file1.fa'},
-        uuid2: {'path': outdir / uuid2, 'assembly_name': 'file2.fa'}
-        }
-
-    ret2 = {
-        uuid1: {'path': outdir / uuid1, 'assembly_name': 'file2.fa'},
-        uuid2: {'path': outdir / uuid2, 'assembly_name': 'file1.fa'}
-        }
-
-    # os.walk doesn't seem to return the file names in any paticular order
-    assert ret == ret1 or ret == ret2
+    assert ret == {Path(outdir) / 'file1.fa': 'file1.fa', Path(outdir) / 'file2.fa': 'file2.fa'}
 
     assert clis.dfu().get_objects.call_args_list == [(({'object_refs': ['34567/3/7']},), {})]
 


### PR DESCRIPTION
No reason for the d/ler to generate the IDs - doesn't need them. Simplifies the API and glue code to have the IDs generated where they're needed