### PR TITLE
PTV-1868: Remove --insecure from curl command in entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER KBase Developer
 # install line here, a git checkout to download code, or run any other
 # installation scripts.
 
-RUN apt-get update
+RUN apt-get update -y
 RUN apt-get install -y libgomp1 unzip
 
 RUN pip install pip --upgrade

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -19,7 +19,7 @@ elif [ "${1}" = "init" ] ; then
   echo "Initialize module"
   cd /data
   echo "Getting GTDB-Tk database"
-  curl --insecure -O https://data.gtdb.ecogenomic.org/releases/release207/207.0/auxillary_files/gtdbtk_r207_v2_data.tar.gz
+  curl -O https://data.gtdb.ecogenomic.org/releases/release207/207.0/auxillary_files/gtdbtk_r207_v2_data.tar.gz
   tar xvzf gtdbtk_r207_v2_data.tar.gz --strip 1
   rm gtdbtk_r207_v2_data.tar.gz
   if [[ -d "taxonomy" && -d "fastani" && -d "markers" ]] ; then


### PR DESCRIPTION
Presumably no longer needed with the newer base image

```
$ docker run -v /media/crushingismybusiness/RAST_SDK_test/test_gtdb_tk_import/:/data gtdb_tk_test init
Traceback (most recent call last):
  File "./scripts/prepare_deploy_cfg.py", line 44, in <module>
    raise ValueError('Neither ' + sys.argv[2] + ' file nor KBASE_ENDPOINT env-variable found')
ValueError: Neither ./work/config.properties file nor KBASE_ENDPOINT env-variable found
Initialize module
Getting GTDB-Tk database
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 62.7G    0 5098k    0     0   162k      0   4d 16h  0:00:31   4d 16h  178k
```