### PR TITLE
PTV-1904 fix column mismatch when merging TSV files

### DIFF
--- a/lib/kb_gtdbtk/core/gtdbtk_runner.py
+++ b/lib/kb_gtdbtk/core/gtdbtk_runner.py
@@ -248,11 +248,12 @@ def _process_output_files(
         tmppath = temp_output / file_folder[file_] / file_
         path = out_dir / file_
         found_file = False
-        num_cols = 0
 
         id_order = []
         tmp_buf = dict()
         # TODO: decompose, avoid duplications, overlap
+        num_tmp_cols = 0
+        num_tree_cols = 0
         if tmppath.is_file():
             found_file = True
             with open(tmppath, 'r') as tmppath_h:
@@ -260,7 +261,7 @@ def _process_output_files(
                     row = info_line.rstrip().split("\t")
                     tmp_buf[row[0]] = row
                     id_order.append(row[0])
-                    num_cols = len(row)
+                    num_tmp_cols = len(row)
         tree_buf = dict()
         if treepath.is_file():
             found_file = True
@@ -270,15 +271,15 @@ def _process_output_files(
                     row = info_line.rstrip().split("\t")
                     tree_buf[row[0]] = row
                     id_order.append(row[0])
-                    num_cols = len(row)
+                    num_tree_cols = len(row)
+
+        num_cols = max(num_tmp_cols, num_tree_cols)
 
         if not found_file:
             continue
         out_buf = []
         for qid in id_order:
-            row = []
-            for field_i in range(num_cols):
-                row.append('N/A')
+            row = ["N/A"] * num_cols
             if qid in tmp_buf:
                 row = tmp_buf[qid]
             if qid in tree_buf:
@@ -340,3 +341,6 @@ def _process_output_files(
             summary_tables[file_] = sj
 
     return (classification, summary_tables)
+
+
+def _load_summary_file(filename: Path) -> :

--- a/lib/kb_gtdbtk/core/gtdbtk_runner.py
+++ b/lib/kb_gtdbtk/core/gtdbtk_runner.py
@@ -341,6 +341,3 @@ def _process_output_files(
             summary_tables[file_] = sj
 
     return (classification, summary_tables)
-
-
-def _load_summary_file(filename: Path) -> :


### PR DESCRIPTION
There's a step in the output file processing where TSV files can get merged. This can throw an error in the edge case where these files have a mismatched number of columns in one or more rows, i.e. when a row has empty columns at the end, which get truncated during processing.

The current fix is to use the maximum number of columns found during processing.

The real fix would be to load the files as a list of dictionaries where each key is a column header and each value is the value of that row, then merge those. That might get preserved for future work.